### PR TITLE
feat(tink-category): create a new service and store Tink categories

### DIFF
--- a/src/hooks/mappers/analysis.mapper.spec.ts
+++ b/src/hooks/mappers/analysis.mapper.spec.ts
@@ -6,7 +6,7 @@ import { tinkProviderObjectMock } from '../../tink/dto/provider.objects.mock';
 import { TinkAccountType } from '../../tink/dto/account.enums';
 import { AccountType, AccountUsage } from '../../algoan/dto/analysis.enum';
 import { Account, AccountTransaction, AnalysisUpdateInput } from '../../algoan/dto/analysis.inputs';
-import { TinkTransactionResponseObject } from '../../tink/dto/search.objects';
+import { ExtendedTinkTransactionResponseObject, TinkTransactionResponseObject } from '../../tink/dto/search.objects';
 import { tinkSearchResponseObjectMock } from '../../tink/dto/search.objects.mock';
 import { TinkProviderObject } from '../../tink/dto/provider.objects';
 import {
@@ -22,7 +22,10 @@ describe('AnalysisMapper', () => {
   describe('mapToAlgaonTransaction', () => {
     it('should return an algoan transaction', async () => {
       // Transaction mock
-      const tinkTransaction: TinkTransactionResponseObject = tinkSearchResponseObjectMock.results[0].transaction;
+      const tinkTransaction: ExtendedTinkTransactionResponseObject = {
+        categoryCode: 'expenses:house.other',
+        ...tinkSearchResponseObjectMock.results[0].transaction,
+      };
 
       // We map it
       const accountTransaction: AccountTransaction = mapToAlgoanTransaction(tinkTransaction);
@@ -38,7 +41,7 @@ describe('AnalysisMapper', () => {
         isComing: tinkTransaction.upcoming,
         aggregator: {
           id: tinkTransaction.id,
-          category: tinkTransaction.categoryType,
+          category: 'expenses:house.other',
           type: tinkTransaction.type,
         },
       });
@@ -294,7 +297,10 @@ describe('AnalysisMapper', () => {
 
     it('should return an algoan analysis with 2 account', async () => {
       // transactions mock
-      const tinkTransactionMock: TinkTransactionResponseObject = tinkSearchResponseObjectMock.results[0].transaction;
+      const tinkTransactionMock: ExtendedTinkTransactionResponseObject = {
+        categoryCode: 'expenses:house.other',
+        ...tinkSearchResponseObjectMock.results[0].transaction,
+      };
 
       // mock
       const tinkTransactionsMock: TinkTransactionResponseObject[] = [
@@ -361,7 +367,7 @@ describe('AnalysisMapper', () => {
             transactions: [
               {
                 aggregator: {
-                  category: 'EXPENSES',
+                  category: 'expenses:house.other',
                   id: '79c6c9c27d6e42489e888e08d27205a1',
                   type: 'CREDIT_CARD',
                 },
@@ -402,7 +408,7 @@ describe('AnalysisMapper', () => {
             transactions: [
               {
                 aggregator: {
-                  category: 'EXPENSES',
+                  category: 'expenses:house.other',
                   id: '79c6c9c27d6e42489e888e08d27205a1',
                   type: 'CREDIT_CARD',
                 },

--- a/src/hooks/mappers/analysis.mapper.spec.ts
+++ b/src/hooks/mappers/analysis.mapper.spec.ts
@@ -12,7 +12,7 @@ import { TinkProviderObject } from '../../tink/dto/provider.objects';
 import {
   defaultCurrency,
   mapTinkDataToAlgoanAnalysis,
-  mapToAlgaonTransaction,
+  mapToAlgoanTransaction,
   mapToAlgoanAccount,
   mapToAlgoanAccountType,
   mapToIbanAndBic,
@@ -25,7 +25,7 @@ describe('AnalysisMapper', () => {
       const tinkTransaction: TinkTransactionResponseObject = tinkSearchResponseObjectMock.results[0].transaction;
 
       // We map it
-      const accountTransaction: AccountTransaction = mapToAlgaonTransaction(tinkTransaction);
+      const accountTransaction: AccountTransaction = mapToAlgoanTransaction(tinkTransaction);
 
       // We get an algoan transaction
       expect(accountTransaction).toEqual({
@@ -55,7 +55,7 @@ describe('AnalysisMapper', () => {
       expect(tinkTransaction.currencyDenominatedOriginalAmount?.currencyCode).toBeUndefined();
 
       // We map it
-      const accountTransaction: AccountTransaction = mapToAlgaonTransaction(tinkTransaction);
+      const accountTransaction: AccountTransaction = mapToAlgoanTransaction(tinkTransaction);
 
       // New transaction has the default currency
       expect(accountTransaction.currency).toEqual(defaultCurrency);
@@ -208,7 +208,7 @@ describe('AnalysisMapper', () => {
         aggregator: {
           id: tinkAccountObjectMock.id,
         },
-        transactions: tinkTransactionsMock.map(mapToAlgaonTransaction),
+        transactions: tinkTransactionsMock.map(mapToAlgoanTransaction),
         ...mapToIbanAndBic(tinkAccountObjectMock.identifiers),
       });
 
@@ -250,7 +250,7 @@ describe('AnalysisMapper', () => {
         aggregator: {
           id: tinkAccountObjectMock.id,
         },
-        transactions: tinkTransactionsMock.map(mapToAlgaonTransaction),
+        transactions: tinkTransactionsMock.map(mapToAlgoanTransaction),
         ...mapToIbanAndBic(tinkAccountObjectMock.identifiers),
       });
     });

--- a/src/hooks/mappers/analysis.mapper.ts
+++ b/src/hooks/mappers/analysis.mapper.ts
@@ -78,7 +78,7 @@ export function mapToAlgoanAccount(
     aggregator: {
       id: tinkAccount.id,
     },
-    transactions: tinkTransactions.map(mapToAlgaonTransaction),
+    transactions: tinkTransactions.map(mapToAlgoanTransaction),
     ...mapToIbanAndBic(tinkAccount.identifiers),
   };
 }
@@ -137,7 +137,7 @@ export function mapToIbanAndBic(identifiers: TinkAccountObject['identifiers']): 
 /**
  * Map To Algoan transaction
  */
-export function mapToAlgaonTransaction(tinkTransaction: TinkTransactionResponseObject): AccountTransaction {
+export function mapToAlgoanTransaction(tinkTransaction: TinkTransactionResponseObject): AccountTransaction {
   return {
     dates: {
       debitedAt: new Date(tinkTransaction.originalDate).toISOString(),

--- a/src/hooks/mappers/analysis.mapper.ts
+++ b/src/hooks/mappers/analysis.mapper.ts
@@ -4,7 +4,7 @@ import { Account, AccountTransaction, AnalysisUpdateInput } from '../../algoan/d
 import { TinkAccountFlag, TinkAccountType } from '../../tink/dto/account.enums';
 import { TinkAccountObject } from '../../tink/dto/account.objects';
 import { TinkProviderObject } from '../../tink/dto/provider.objects';
-import { TinkTransactionResponseObject } from '../../tink/dto/search.objects';
+import { ExtendedTinkTransactionResponseObject, TinkTransactionResponseObject } from '../../tink/dto/search.objects';
 
 /**
  * Default currency if no provided
@@ -137,7 +137,7 @@ export function mapToIbanAndBic(identifiers: TinkAccountObject['identifiers']): 
 /**
  * Map To Algoan transaction
  */
-export function mapToAlgoanTransaction(tinkTransaction: TinkTransactionResponseObject): AccountTransaction {
+export function mapToAlgoanTransaction(tinkTransaction: ExtendedTinkTransactionResponseObject): AccountTransaction {
   return {
     dates: {
       debitedAt: new Date(tinkTransaction.originalDate).toISOString(),
@@ -148,7 +148,7 @@ export function mapToAlgoanTransaction(tinkTransaction: TinkTransactionResponseO
     isComing: tinkTransaction.upcoming,
     aggregator: {
       id: tinkTransaction.id,
-      category: tinkTransaction.categoryType,
+      category: tinkTransaction.categoryCode,
       type: tinkTransaction.type,
     },
   };

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -9,7 +9,7 @@ import { TinkAccountService } from '../../tink/services/tink-account.service';
 import { TinkProviderService } from '../../tink/services/tink-provider.service';
 import { TinkTransactionService } from '../../tink/services/tink-transaction.service';
 import { TinkProviderObject } from '../../tink/dto/provider.objects';
-import { TinkTransactionResponseObject } from '../../tink/dto/search.objects';
+import { ExtendedTinkTransactionResponseObject, TinkTransactionResponseObject } from '../../tink/dto/search.objects';
 import { AnalysisUpdateInput } from '../../algoan/dto/analysis.inputs';
 import { TINK_LINK_ACTOR_CLIENT_ID } from '../../tink/contstants/tink.constants';
 import { Customer } from '../../algoan/dto/customer.objects';
@@ -154,7 +154,7 @@ export class HooksService {
 
     // Get bank information
     const accounts: TinkAccountObject[] = await this.tinkAccountService.getAccounts();
-    const transactions: TinkTransactionResponseObject[] = await this.tinkTransactionService.getTransactions({
+    const transactions: ExtendedTinkTransactionResponseObject[] = await this.tinkTransactionService.getTransactions({
       accounts: accounts.map((a: TinkAccountObject) => a.id),
     });
     const providers: TinkProviderObject[] = await this.tinkProviderService.getProviders();

--- a/src/tink/dto/category.object.mock.ts
+++ b/src/tink/dto/category.object.mock.ts
@@ -1,0 +1,31 @@
+import { TinkCategory } from './category.object';
+import { TinkTransactionCategoryType } from './transaction.enums';
+
+export const tinkCategoryListMock: TinkCategory[] = [
+  {
+    code: 'expenses:house.other',
+    defaultChild: true,
+    id: '01f944531ab04cd3ba32a14cebe8a927',
+    parent: '9308a083665741588b88d9160aedf968',
+    primaryName: 'Home Improvements',
+    // eslint-disable-next-line no-null/no-null
+    searchTerms: null,
+    secondaryName: 'Home Improvements Other',
+    sortOrder: 14,
+    type: TinkTransactionCategoryType.EXPENSES,
+    typeName: 'Expenses',
+  },
+  {
+    code: 'expenses:misc.outlays',
+    defaultChild: false,
+    id: '0217989903af43c5b7b4e66c0515d0d5',
+    parent: '99dd6d0c05a347d1858daa219e21c573',
+    primaryName: 'Other',
+    // eslint-disable-next-line no-null/no-null
+    searchTerms: null,
+    secondaryName: 'Business Expenses',
+    sortOrder: 49,
+    type: TinkTransactionCategoryType.EXPENSES,
+    typeName: 'Expenses',
+  },
+];

--- a/src/tink/dto/category.object.ts
+++ b/src/tink/dto/category.object.ts
@@ -1,0 +1,18 @@
+import { TinkTransactionCategoryType } from './transaction.enums';
+
+/**
+ * Tink category object
+ * Can be retrieved here: https://docs.tink.com/api#category
+ */
+export interface TinkCategory {
+  code: string;
+  defaultChild: boolean;
+  id: string;
+  parent: string;
+  primaryName: string;
+  searchTerms: string | null;
+  secondaryName: string;
+  sortOrder: number;
+  type: TinkTransactionCategoryType;
+  typeName: string;
+}

--- a/src/tink/dto/search.objects.mock.ts
+++ b/src/tink/dto/search.objects.mock.ts
@@ -14,6 +14,7 @@ export const tinkSearchResponseObjectMock: TinkSearchResponseObject = {
         id: '79c6c9c27d6e42489e888e08d27205a1',
         accountId: tinkAccountObjectMock.id,
         amount: 34.5,
+        categoryId: '01f944531ab04cd3ba32a14cebe8a927',
         categoryType: TinkTransactionCategoryType.EXPENSES,
         currencyDenominatedOriginalAmount: {
           currencyCode: 'EUR',

--- a/src/tink/dto/search.objects.ts
+++ b/src/tink/dto/search.objects.ts
@@ -34,6 +34,7 @@ export interface TinkTransactionResponseObject<NullOrUndefined = undefined> {
   id: string;
   accountId: string;
   amount: number;
+  categoryId: string;
   categoryType: TinkTransactionCategoryType;
   currencyDenominatedOriginalAmount: TinkCurrencyDenominatedAmountObject | NullOrUndefined;
   originalDate: number; // timestamp
@@ -41,6 +42,15 @@ export interface TinkTransactionResponseObject<NullOrUndefined = undefined> {
   type: TinkTransactionType;
   upcoming: boolean | NullOrUndefined;
 }
+
+/**
+ * Extends Tink transaction with the category code
+ */
+export type ExtendedTinkTransactionResponseObject<
+  NullOrUndefined = undefined
+> = TinkTransactionResponseObject<NullOrUndefined> & {
+  categoryCode?: string;
+};
 
 /**
  * Currency Denominated Amount Object

--- a/src/tink/services/tink-category.service.spec.ts
+++ b/src/tink/services/tink-category.service.spec.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/naming-convention,camelcase */
+import { HttpModule, HttpService } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AxiosResponse } from 'axios';
+import { config } from 'node-config-ts';
+import { of } from 'rxjs';
+import { ContextIdFactory } from '@nestjs/core';
+
+import { CONFIG } from '../../config/config.module';
+import { tinkCategoryListMock } from '../dto/category.object.mock';
+import { TinkCategory } from '../dto/category.object';
+import { TinkCategoryService } from './tink-category.service';
+
+describe('TinkCategoryService', () => {
+  let tinkCategoryService: TinkCategoryService;
+  let httpService: HttpService;
+
+  beforeEach(async () => {
+    // To mock scoped DI
+    const contextId = ContextIdFactory.create();
+    jest.spyOn(ContextIdFactory, 'getByRequest').mockImplementation(() => contextId);
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [HttpModule],
+      providers: [
+        TinkCategoryService,
+        {
+          provide: CONFIG,
+          useValue: config,
+        },
+      ],
+    }).compile();
+
+    tinkCategoryService = await moduleRef.resolve<TinkCategoryService>(TinkCategoryService, contextId);
+    httpService = await moduleRef.resolve<HttpService>(HttpService, contextId);
+    jest.spyOn(httpService, 'get').mockReturnValue(of({ data: tinkCategoryListMock } as AxiosResponse<TinkCategory[]>));
+
+    await tinkCategoryService.onModuleInit();
+  });
+
+  it('should be defined', () => {
+    expect(tinkCategoryService).toBeDefined();
+  });
+
+  it('should fill the category list', async () => {
+    const expectedLength: number = 2;
+
+    expect(tinkCategoryService.categories).toHaveLength(expectedLength);
+  });
+
+  describe('getCategoryById', () => {
+    it('should properly return the correct code', async () => {
+      expect(tinkCategoryService.getCategoryCodeById('01f944531ab04cd3ba32a14cebe8a927')).toEqual(
+        'expenses:house.other',
+      );
+      expect(tinkCategoryService.getCategoryCodeById('0217989903af43c5b7b4e66c0515d0d5')).toEqual(
+        'expenses:misc.outlays',
+      );
+    });
+
+    it('should return undefined', async () => {
+      expect(tinkCategoryService.getCategoryCodeById('random')).toBeUndefined();
+    });
+  });
+});

--- a/src/tink/services/tink-category.service.ts
+++ b/src/tink/services/tink-category.service.ts
@@ -23,7 +23,7 @@ export class TinkCategoryService implements OnModuleInit {
    */
   public async onModuleInit(): Promise<void> {
     const response: AxiosResponse<TinkCategory[]> = await this.httpService
-      .get(`${this.config.tink.apiBaseUrl}/v1/categories`)
+      .get(`${this.config.tink.apiBaseUrl}/api/v1/categories`)
       .toPromise();
 
     this.categories = response.data;

--- a/src/tink/services/tink-category.service.ts
+++ b/src/tink/services/tink-category.service.ts
@@ -1,0 +1,39 @@
+import { HttpService, Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { AxiosResponse } from 'axios';
+import { Config } from 'node-config-ts';
+
+import { CONFIG } from '../../config/config.module';
+import { TinkCategory } from '../dto/category.object';
+
+/**
+ * Service to manage transaction
+ */
+@Injectable()
+export class TinkCategoryService implements OnModuleInit {
+  constructor(@Inject(CONFIG) private readonly config: Config, private readonly httpService: HttpService) {}
+
+  /**
+   * Store Tink categories
+   */
+  public categories: TinkCategory[];
+
+  /**
+   * Method started when the application starts
+   * Looks for Tink categories and store them
+   */
+  public async onModuleInit(): Promise<void> {
+    const response: AxiosResponse<TinkCategory[]> = await this.httpService
+      .get(`${this.config.tink.apiBaseUrl}/v1/categories`)
+      .toPromise();
+
+    this.categories = response.data;
+  }
+
+  /**
+   * Fetch category code by id
+   * @param id Category identifier
+   */
+  public getCategoryCodeById(id: string): string | undefined {
+    return this.categories.find((value: TinkCategory) => value.id === id)?.code;
+  }
+}

--- a/src/tink/services/tink-transaction.service.spec.ts
+++ b/src/tink/services/tink-transaction.service.spec.ts
@@ -9,8 +9,10 @@ import { CONFIG } from '../../config/config.module';
 import { TinkSearchResponseObject, TinkSearchResultObject, TinkTransactionResponseObject } from '../dto/search.objects';
 import { tinkSearchResponseObjectMock } from '../dto/search.objects.mock';
 import { TinkSearchQueryInput } from '../dto/search.input';
+import { tinkCategoryListMock } from '../dto/category.object.mock';
 import { TinkTransactionService } from './tink-transaction.service';
 import { TinkHttpService } from './tink-http.service';
+import { TinkCategoryService } from './tink-category.service';
 
 describe('TinkSearchService', () => {
   let tinkTransactionService: TinkTransactionService;
@@ -26,6 +28,7 @@ describe('TinkSearchService', () => {
       providers: [
         TinkHttpService,
         TinkTransactionService,
+        TinkCategoryService,
         {
           provide: CONFIG,
           useValue: config,
@@ -35,6 +38,12 @@ describe('TinkSearchService', () => {
 
     tinkTransactionService = await moduleRef.resolve<TinkTransactionService>(TinkTransactionService, contextId);
     tinkHttpService = await moduleRef.resolve<TinkHttpService>(TinkHttpService, contextId);
+    const tinkCategoryService: TinkCategoryService = await moduleRef.resolve<TinkCategoryService>(
+      TinkCategoryService,
+      contextId,
+    );
+
+    tinkCategoryService.categories = tinkCategoryListMock;
   });
 
   it('should be defined', () => {
@@ -56,7 +65,10 @@ describe('TinkSearchService', () => {
 
       expect(spy).toHaveBeenCalledWith(`/api/v1/search`, input);
       expect(transactions).toEqual(
-        tinkSearchResponseObjectMock.results.map((r: TinkSearchResultObject) => r.transaction),
+        tinkSearchResponseObjectMock.results.map((r: TinkSearchResultObject) => ({
+          categoryCode: 'expenses:house.other',
+          ...r.transaction,
+        })),
       );
     });
 

--- a/src/tink/tink.module.ts
+++ b/src/tink/tink.module.ts
@@ -8,6 +8,7 @@ import { TinkUserService } from './services/tink-user.service';
 import { TinkAccountService } from './services/tink-account.service';
 import { TinkProviderService } from './services/tink-provider.service';
 import { TinkTransactionService } from './services/tink-transaction.service';
+import { TinkCategoryService } from './services/tink-category.service';
 
 /**
  * Hooks module
@@ -21,6 +22,7 @@ import { TinkTransactionService } from './services/tink-transaction.service';
     TinkUserService,
     TinkProviderService,
     TinkTransactionService,
+    TinkCategoryService,
   ],
   exports: [
     TinkAccountService,
@@ -29,6 +31,7 @@ import { TinkTransactionService } from './services/tink-transaction.service';
     TinkUserService,
     TinkProviderService,
     TinkTransactionService,
+    TinkCategoryService,
   ],
 })
 export class TinkModule {}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "**/*mock.ts"]
 }


### PR DESCRIPTION
### Description

Send Tink category to Algoan. In order to do this, I've created a `TinkCategoryService` which stores locally all Tink categories.

- Create a new `TinkCategoryService` with its test file
- Correct a spelling mistake on a mapper method
- Skip `mock.ts` file in the Typescript build
- Extend Tink's transactions with the category's code, and send it to Algoan
