### PR TITLE
[FIX] Add bookedDate when mapping to Algoan transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nestjs-connector-boilerplate",
+  "name": "@algoan/nestjs-tink-connector",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nestjs-connector-boilerplate",
+      "name": "@algoan/nestjs-tink-connector",
       "version": "0.0.1",
       "hasInstallScript": true,
       "license": "UNLICENSED",

--- a/src/hooks/mappers/analysis.mapper.spec.ts
+++ b/src/hooks/mappers/analysis.mapper.spec.ts
@@ -19,7 +19,7 @@ import {
 } from './analysis.mapper';
 
 describe('AnalysisMapper', () => {
-  describe('mapToAlgaonTransaction', () => {
+  describe('mapToAlgoanTransaction', () => {
     it('should return an algoan transaction', async () => {
       // Transaction mock
       const tinkTransaction: ExtendedTinkTransactionResponseObject = {
@@ -34,6 +34,7 @@ describe('AnalysisMapper', () => {
       expect(accountTransaction).toEqual({
         dates: {
           debitedAt: '2016-02-17T20:27:54.875Z',
+          bookedAt: '2016-02-17T20:27:54.875Z',
         },
         description: tinkTransaction.originalDescription,
         amount: tinkTransaction.amount,
@@ -375,6 +376,7 @@ describe('AnalysisMapper', () => {
                 currency: 'EUR',
                 dates: {
                   debitedAt: isoString, // Force because of currentDate ....
+                  bookedAt: isoString,
                 },
                 description: 'Stadium Sergelg Stockholm',
                 isComing: false,
@@ -416,6 +418,7 @@ describe('AnalysisMapper', () => {
                 currency: 'EUR',
                 dates: {
                   debitedAt: isoString, // Force because of currentDate ....
+                  bookedAt: isoString,
                 },
                 description: `Stadium Sergelg Stockholm-${process.pid}`,
                 isComing: false,

--- a/src/hooks/mappers/analysis.mapper.ts
+++ b/src/hooks/mappers/analysis.mapper.ts
@@ -141,6 +141,7 @@ export function mapToAlgoanTransaction(tinkTransaction: ExtendedTinkTransactionR
   return {
     dates: {
       debitedAt: new Date(tinkTransaction.originalDate).toISOString(),
+      bookedAt: new Date(tinkTransaction.originalDate).toISOString(),
     },
     description: tinkTransaction.originalDescription,
     amount: tinkTransaction.amount,


### PR DESCRIPTION
* Add `bookedDate` when mapping from Tink transaction to Algoan transaction