### PR TITLE
[FEAT] Add "refresh" mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23261,13 +23261,12 @@
     "@algoan/nestjs-logging-interceptor": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@algoan/nestjs-logging-interceptor/-/nestjs-logging-interceptor-2.1.7.tgz",
-      "integrity": "sha512-8IyKWCrdya2jdevLayWaaO8lE1wDySvcKNdhKTufdelRLmGZbSsqYJkz61h/+S7qofpOh5d27snEZJeqN7HinA==",
-      "requires": {}
+      "integrity": "sha512-8IyKWCrdya2jdevLayWaaO8lE1wDySvcKNdhKTufdelRLmGZbSsqYJkz61h/+S7qofpOh5d27snEZJeqN7HinA=="
     },
     "@algoan/rest": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@algoan/rest/-/rest-2.3.0.tgz",
-      "integrity": "sha512-q5D6jgEcpwCAaXW3Vrsw1vEjf36fsXdF4wrW6x2hlRhL0yT2pV1B7AkLb4JwhzuaCVr7L9YejiJxDCOhXgHVJA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@algoan/rest/-/rest-2.3.1.tgz",
+      "integrity": "sha512-MzqpSH4fnXvU8JQM019UT3eGY0jeTSALHOnNI9CLD7mYvmoeyAPLD28p4WD4SgDxDsmwVcgr+I3xZhj0zNNItA==",
       "requires": {
         "axios": "^0.21.1",
         "form-data": "^4.0.0",
@@ -25502,8 +25501,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
       "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.0.0",
@@ -26607,6 +26605,16 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -26702,8 +26710,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -28688,8 +28695,8 @@
       "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
       "dev": true,
       "requires": {
-        "is-text-path": "^1.0.1",
         "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.1",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
@@ -33609,16 +33616,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -36892,14 +36889,6 @@
             "minipass": "^3.1.1"
           }
         },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
@@ -36922,6 +36911,14 @@
                 "ansi-regex": "^3.0.0"
               }
             }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         },
         "stringify-package": {
@@ -39412,11 +39409,6 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-argv": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -39608,6 +39600,11 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringify-object": {
       "version": "3.3.0",
@@ -40913,77 +40910,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
       "dev": true
-    },
-    "webpack": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.31.0.tgz",
-      "integrity": "sha512-3fUfZT/FUuThWSSyL32Fsh7weUUfYP/Fjc/cGSbla5KiSo0GtI1JMssCRUopJTvmLjrw05R2q7rlLtiKdSzkzQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@types/eslint-scope": "^3.7.0",
-        "@types/estree": "^0.0.46",
-        "@webassemblyjs/ast": "1.11.0",
-        "@webassemblyjs/wasm-edit": "1.11.0",
-        "@webassemblyjs/wasm-parser": "1.11.0",
-        "acorn": "^8.0.4",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.7.0",
-        "es-module-lexer": "^0.4.0",
-        "eslint-scope": "^5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.4",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.0.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.1.1",
-        "watchpack": "^2.0.0",
-        "webpack-sources": "^2.1.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-          "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
-          "dev": true,
-          "peer": true
-        },
-        "enhanced-resolve": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
-          "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.2.4",
-            "tapable": "^2.2.0"
-          }
-        },
-        "schema-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@types/json-schema": "^7.0.6",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        },
-        "tapable": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
-          "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
-          "dev": true,
-          "peer": true
-        }
-      }
     },
     "webpack-node-externals": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@algoan/nestjs-http-exception-filter": "^1.0.9",
     "@algoan/nestjs-logging-interceptor": "^2.1.7",
-    "@algoan/rest": "^2.3.0",
+    "@algoan/rest": "^2.3.1",
     "@nestjs/common": "^7.6.15",
     "@nestjs/core": "^7.6.15",
     "@nestjs/platform-express": "^7.6.15",

--- a/src/hooks/dto/bank-details-required-payload.dto.ts
+++ b/src/hooks/dto/bank-details-required-payload.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 /**
  * Payload for event `bank_details_required`
  */
@@ -19,8 +19,10 @@ export class BankDetailsRequiredDTO {
 
   /**
    * Temp code to convert to an access token
+   *
+   * If not defined, the event is considered as a refresh
    */
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  public temporaryCode: string;
+  public temporaryCode?: string;
 }

--- a/src/tink/services/tink-http.service.ts
+++ b/src/tink/services/tink-http.service.ts
@@ -36,6 +36,24 @@ export class TinkHttpService {
   /**
    * Authenticate the service to tink
    */
+  public async authenticateAsClientWithRefreshToken(
+    clientId: string,
+    clientSecret: string,
+    refreshToken: string,
+  ): Promise<void> {
+    const input: AccessTokenInput = {
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: GrantType.REFRESH_TOKEN,
+      refresh_token: refreshToken,
+    };
+
+    return this.authenticate(input);
+  }
+
+  /**
+   * Authenticate the service to tink
+   */
   public async authenticateAsUserWithCode(clientId: string, clientSecret: string, code: string): Promise<void> {
     const input: AccessTokenInput = {
       client_id: clientId,
@@ -100,6 +118,17 @@ export class TinkHttpService {
       .toPromise();
 
     return response.data;
+  }
+
+  /**
+   * Get tink refresh token
+   */
+  public getRefreshToken(): string {
+    if (this.tokenInfo === undefined) {
+      throw new Error('You should be authenticated before requesting Tink');
+    }
+
+    return this.tokenInfo.refresh_token;
   }
 
   /**


### PR DESCRIPTION
The goal of this PR is to refresh the bank details previoulsy aggregated from one customer without requiring a new authentication from the end-user.

Details:

- Save the `resfresh_token` after its creation
- Authenticate with the `refresh_token` when no temporaryCode in payload
- Put payload.temporaryCode as optional, and considered it as a "refresh" mode if absent