### PR TITLE
feat: handle iframe mode

### DIFF
--- a/json-server/db.json
+++ b/json-server/db.json
@@ -4,7 +4,8 @@
       "id": "5f58a224aa55a30021bc7b01",
       "customIdentifier": "client_unique_identifier",
       "aggregationDetails": {
-        "callbackUrl": "http://localhost:4000/callback"
+        "callbackUrl": "http://localhost:4000/callback",
+        "mode": "REDIRECT"
       }
     }
   ],

--- a/src/algoan/dto/customer.enums.ts
+++ b/src/algoan/dto/customer.enums.ts
@@ -4,6 +4,7 @@
 export enum AggregationDetailsMode {
   redirect = 'REDIRECT',
   api = 'API',
+  iframe = 'IFRAME'
 }
 
 /**

--- a/src/algoan/dto/customer.enums.ts
+++ b/src/algoan/dto/customer.enums.ts
@@ -4,7 +4,7 @@
 export enum AggregationDetailsMode {
   redirect = 'REDIRECT',
   api = 'API',
-  iframe = 'IFRAME'
+  iframe = 'IFRAME',
 }
 
 /**

--- a/src/algoan/dto/customer.inputs.ts
+++ b/src/algoan/dto/customer.inputs.ts
@@ -13,6 +13,7 @@ export interface AggregationDetailsUpdateInput {
   token?: string;
   redirectUrl?: string;
   apiUrl?: string;
+  iframeUrl?: string;
   userId?: string;
   clientId?: string;
 }

--- a/src/algoan/dto/customer.objects.ts
+++ b/src/algoan/dto/customer.objects.ts
@@ -20,6 +20,7 @@ export interface AggregationDetails {
   mode?: AggregationDetailsMode;
   redirectUrl?: string;
   apiUrl?: string;
+  iframeUrl?: string
   userId?: string;
   clientId?: string;
 }

--- a/src/algoan/dto/customer.objects.ts
+++ b/src/algoan/dto/customer.objects.ts
@@ -20,7 +20,7 @@ export interface AggregationDetails {
   mode?: AggregationDetailsMode;
   redirectUrl?: string;
   apiUrl?: string;
-  iframeUrl?: string
+  iframeUrl?: string;
   userId?: string;
   clientId?: string;
 }

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -41,7 +41,7 @@ import { TINK_LINK_ACTOR_CLIENT_ID } from '../../tink/contstants/tink.constants'
 
 import { bankDetailsRequiredMock } from '../dto/bank-details-required-payload.dto.mock';
 import { mapTinkDataToAlgoanAnalysis } from '../mappers/analysis.mapper';
-import { AggregationDetailsMode } from '../../algoan/dto/customer.enums'
+import { AggregationDetailsMode } from '../../algoan/dto/customer.enums';
 import { HooksService } from './hooks.service';
 
 describe('HookService', () => {
@@ -286,7 +286,7 @@ describe('HookService', () => {
         ...customerMock,
         aggregationDetails: {
           ...customerMock.aggregationDetails,
-          mode: AggregationDetailsMode.iframe
+          mode: AggregationDetailsMode.iframe,
         },
       });
       await hookService.handleAggregatorLinkRequiredEvent(aggregatorLinkRequiredMock);
@@ -298,7 +298,7 @@ describe('HookService', () => {
         scope: 'accounts:read,transactions:read,credentials:read',
         test: config.tink.test,
         authorization_code: createAuthorizationObjectMock.code,
-        iframe: true
+        iframe: true,
       });
 
       // update
@@ -404,7 +404,7 @@ describe('HookService', () => {
       expect(tinkAuthenticateWithRefreshTokenSpy).toHaveBeenCalledWith(
         serviceAccountConfigMock.clientId,
         serviceAccountConfigMock.clientSecret,
-        'mockRefreshToken'
+        'mockRefreshToken',
       );
       expect(tinkAuthenticateAsUserWithCodesSpy).not.toHaveBeenCalled();
 

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -161,7 +161,7 @@ describe('HookService', () => {
       );
     });
 
-    it('should do these steps if pricing STANDARD', async () => {
+    it('should do these steps if pricing STANDARD (redirect mode)', async () => {
       serviceAccountConfigMock.pricing = ClientPricing.STANDARD;
       await hookService.handleAggregatorLinkRequiredEvent(aggregatorLinkRequiredMock);
 
@@ -192,7 +192,7 @@ describe('HookService', () => {
       });
     });
 
-    it('should do these steps if pricing PREMIUM WITHOUT an existing tink user', async () => {
+    it('should do these steps if pricing PREMIUM WITHOUT an existing tink user (redirect mode)', async () => {
       serviceAccountConfigMock.pricing = ClientPricing.PREMIUM;
       await hookService.handleAggregatorLinkRequiredEvent(aggregatorLinkRequiredMock);
 
@@ -235,7 +235,7 @@ describe('HookService', () => {
       });
     });
 
-    it('should do these steps if pricing PREMIUM WITH an existing tink user', async () => {
+    it('should do these steps if pricing PREMIUM WITH an existing tink user (redirect mode)', async () => {
       // mock to return an existing userId
       getCustomerByIdSpy = jest.spyOn(algoanCustomerService, 'getCustomerById').mockResolvedValue({
         ...customerMock,

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -41,6 +41,7 @@ import { TINK_LINK_ACTOR_CLIENT_ID } from '../../tink/contstants/tink.constants'
 
 import { bankDetailsRequiredMock } from '../dto/bank-details-required-payload.dto.mock';
 import { mapTinkDataToAlgoanAnalysis } from '../mappers/analysis.mapper';
+import { AggregationDetailsMode } from '../../algoan/dto/customer.enums'
 import { HooksService } from './hooks.service';
 
 describe('HookService', () => {
@@ -275,6 +276,35 @@ describe('HookService', () => {
       expect(updateCustomerSpy).toHaveBeenCalledWith(aggregatorLinkRequiredMock.customerId, {
         aggregationDetails: {
           redirectUrl: 'MY_LINK_URL',
+          userId: createUserObject.user_id,
+        },
+      });
+    });
+
+    it('should generate an iframe link and should update the customer with the new iframe URL', async () => {
+      getCustomerByIdSpy = jest.spyOn(algoanCustomerService, 'getCustomerById').mockResolvedValue({
+        ...customerMock,
+        aggregationDetails: {
+          ...customerMock.aggregationDetails,
+          mode: AggregationDetailsMode.iframe
+        },
+      });
+      await hookService.handleAggregatorLinkRequiredEvent(aggregatorLinkRequiredMock);
+      expect(getLinkSpy).toHaveBeenCalledWith({
+        client_id: serviceAccountConfigMock.clientId,
+        redirect_uri: customerMock.aggregationDetails.callbackUrl,
+        market: serviceAccountConfigMock.market,
+        locale: serviceAccountConfigMock.locale,
+        scope: 'accounts:read,transactions:read,credentials:read',
+        test: config.tink.test,
+        authorization_code: createAuthorizationObjectMock.code,
+        iframe: true
+      });
+
+      // update
+      expect(updateCustomerSpy).toHaveBeenCalledWith(aggregatorLinkRequiredMock.customerId, {
+        aggregationDetails: {
+          iframeUrl: 'MY_LINK_URL',
           userId: createUserObject.user_id,
         },
       });

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -3,8 +3,8 @@ import { ServiceAccount } from '@algoan/rest';
 import { Injectable, Inject } from '@nestjs/common';
 import { Config } from 'node-config-ts';
 
-import { AggregationDetailsMode } from '../../algoan/dto/customer.enums'
-import { CustomerUpdateInput } from '../../algoan/dto/customer.inputs'
+import { AggregationDetailsMode } from '../../algoan/dto/customer.enums';
+import { CustomerUpdateInput } from '../../algoan/dto/customer.inputs';
 import { assertsTypeValidation } from '../../shared/utils/common.utils';
 import { TinkAccountObject } from '../../tink/dto/account.objects';
 import { TinkAccountService } from '../../tink/services/tink-account.service';
@@ -29,7 +29,7 @@ import { AlgoanHttpService } from '../../algoan/services/algoan-http.service';
 import { AggregatorLinkRequiredDTO } from '../dto/aggregator-link-required-payload.dto';
 import { BankDetailsRequiredDTO } from '../dto/bank-details-required-payload.dto';
 import { mapTinkDataToAlgoanAnalysis } from '../mappers/analysis.mapper';
-import { AccountCheckArgs } from '../../tink/dto/account-check.args'
+import { AccountCheckArgs } from '../../tink/dto/account-check.args';
 
 /**
  * Hook service
@@ -109,7 +109,10 @@ export class HooksService {
       });
     }
 
-    const linkData: CustomerUpdateInput["aggregationDetails"] = this.generateLinkDataFromAggregationMode(customer.aggregationDetails.mode, { clientConfig, callbackUrl, authorizationCode})
+    const linkData: CustomerUpdateInput['aggregationDetails'] = this.generateLinkDataFromAggregationMode(
+      customer.aggregationDetails.mode,
+      { clientConfig, callbackUrl, authorizationCode },
+    );
 
     // Update user with redirect link information and userId if provided
     await this.algoanCustomerService.updateCustomer(payload.customerId, {
@@ -128,8 +131,11 @@ export class HooksService {
    * @param data the input data used for to generate the link data
    * @returns
    */
-  private generateLinkDataFromAggregationMode(mode: AggregationDetailsMode | undefined, data: { clientConfig: ClientConfig, callbackUrl: string, authorizationCode?: string}): CustomerUpdateInput["aggregationDetails"] {
-    const { clientConfig, callbackUrl, authorizationCode} = data
+  private generateLinkDataFromAggregationMode(
+    mode: AggregationDetailsMode | undefined,
+    data: { clientConfig: ClientConfig; callbackUrl: string; authorizationCode?: string },
+  ): CustomerUpdateInput['aggregationDetails'] {
+    const { clientConfig, callbackUrl, authorizationCode } = data;
     const sharedLinkParameters: AccountCheckArgs = {
       client_id: clientConfig.clientId,
       redirect_uri: callbackUrl,
@@ -142,18 +148,20 @@ export class HooksService {
         'credentials:read', // To list providers: https://docs.tink.com/api#provider-list-providers-required-scopes-
       ].join(','),
       authorization_code: authorizationCode,
-    }
-
+    };
 
     switch (mode) {
       case AggregationDetailsMode.redirect:
         const redirectUrl: string | undefined = this.tinkLinkService.getAuthorizeLink(sharedLinkParameters);
 
-        return { redirectUrl }
+        return { redirectUrl };
       case AggregationDetailsMode.iframe:
-        const iframeUrl: string | undefined = this.tinkLinkService.getAuthorizeLink({...sharedLinkParameters, iframe: true});
+        const iframeUrl: string | undefined = this.tinkLinkService.getAuthorizeLink({
+          ...sharedLinkParameters,
+          iframe: true,
+        });
 
-        return { iframeUrl }
+        return { iframeUrl };
 
       default:
         throw new Error(`Invalid bank connection mode ${mode}`);

--- a/src/tink/dto/account-check.args.ts
+++ b/src/tink/dto/account-check.args.ts
@@ -13,4 +13,5 @@ export interface AccountCheckArgs {
   scope?: string;
   test: boolean;
   authorization_code?: string;
+  iframe?: boolean
 }

--- a/src/tink/dto/account-check.args.ts
+++ b/src/tink/dto/account-check.args.ts
@@ -13,5 +13,5 @@ export interface AccountCheckArgs {
   scope?: string;
   test: boolean;
   authorization_code?: string;
-  iframe?: boolean
+  iframe?: boolean;
 }


### PR DESCRIPTION
This PR handles the new iframe mode for this connector. Basically, it consists in sending the `iframeUrl` to Algoan server, which is the same as the `redirectUrl` but with an extra query param `iframe=true` (cf. [Tink documentation](https://docs.tink.com/resources/tink-link-web/tink-link-web-embed-in-iframe#configure-for-iframe-in-the-url))

The test application will be updated in another PR.